### PR TITLE
Use tfc-cli v0.5.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://frostedcarbon/tfc-cli:v0.5.0"
+  image: "docker://frostedcarbon/tfc-cli:v0.5.1"
   args:
     - workspaces
     - show

--- a/action.yml
+++ b/action.yml
@@ -22,4 +22,3 @@ runs:
     - ${{ inputs.orgName }}
     - -workspace
     - ${{ inputs.workspaceName }}
-    - -quiet


### PR DESCRIPTION
This version's Docker image has had CA root certificates added, which resolves SSL errors invoking the Terraform Cloud API. I used the solution documented [here](https://medium.com/on-docker/use-multi-stage-builds-to-inject-ca-certs-ad1e8f01de1b).